### PR TITLE
fix: Fix bundling

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,5 @@ export type {
   TileMatrix,
   TileMatrixSet,
 } from "./types/index";
+
+export { metersPerUnit } from "./utils";


### PR DESCRIPTION
Since we were only exporting types and no actual code, it appears that the TS compiler removed all types from the export.

Since we're now exporting `metersPerUnit` (as we want to do anyways), it appears that we're correctly publishing types too