### PR TITLE
ci: Fix release script with git recursive submodules

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          submodules: "recursive"
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
We run `pnpm test` in the release script, so we need the OGC TMS submodule to exist.