### PR TITLE
ci: Fix accessing version in release script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,7 @@ jobs:
       - run: pnpm test
       - name: Read version and publish
         run: |
-          # All packages are expected to have the same version
-          VERSION=$(jq -r .version packages/deck.gl-raster/package.json)
+          VERSION=$(jq -r .version package.json)
           if [[ "$VERSION" == *alpha* || "$VERSION" == *beta* ]]; then
             pnpm publish --recursive --no-git-checks --tag beta
           else


### PR DESCRIPTION
This was copied from https://github.com/developmentseed/deck.gl-raster, which is a monorepo so the path to the package.json was different.